### PR TITLE
feat: add SQL DDL schema extraction support

### DIFF
--- a/src/adapters/bootstrap.ts
+++ b/src/adapters/bootstrap.ts
@@ -9,6 +9,7 @@ import { registerAdapter } from './registry.js';
 import { MCPAdapter } from './mcp.js';
 import { OpenAPIAdapter } from './openapi/index.js';
 import { TRPCAdapter } from './trpc/index.js';
+import { SQLAdapter } from './sql/index.js';
 
 /**
  * Bootstrap the adapter registry with all built-in adapters.
@@ -19,6 +20,7 @@ import { TRPCAdapter } from './trpc/index.js';
  * - **MCP Adapter** (`mcp`): For MCP tool schemas
  * - **OpenAPI Adapter** (`openapi`): For OpenAPI/Swagger specifications
  * - **tRPC Adapter** (`trpc`): For tRPC router definitions
+ * - **SQL Adapter** (`sql_ddl`): For SQL DDL (CREATE TABLE, CREATE TYPE)
  *
  * Multiple calls are safe due to last-wins replacement semantics.
  *
@@ -44,6 +46,9 @@ export function bootstrapAdapters(): void {
 
   // Register tRPC adapter for tRPC router definitions
   registerAdapter(new TRPCAdapter());
+
+  // Register SQL adapter for SQL DDL (CREATE TABLE, CREATE TYPE)
+  registerAdapter(new SQLAdapter());
 
   if (process.env.DEBUG_TRACE_MCP) {
     console.error('[AdapterBootstrap] Built-in adapters registered');

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -21,7 +21,7 @@
  * 
  * ## Available Exports
  * 
- * - **Adapters**: MCPAdapter
+ * - **Adapters**: MCPAdapter, OpenAPIAdapter, TRPCAdapter, SQLAdapter
  * - **Registry Functions**: registerAdapter, getAdapter, hasAdapter, listAdapters
  * - **High-Level Functions**: extractSchema, listSchemas, getAdapterForRef
  * - **Bootstrap**: bootstrapAdapters
@@ -37,6 +37,7 @@
 export { MCPAdapter } from './mcp.js';
 export { OpenAPIAdapter, parseOpenAPIRef, type OpenAPIRef } from './openapi/index.js';
 export { TRPCAdapter, parseTRPCRef, type TRPCRef } from './trpc/index.js';
+export { SQLAdapter, DDLParser, parseDDL, SQL_TYPE_MAP, type SQLTable, type SQLColumn, type SQLEnum, type SQLDialect } from './sql/index.js';
 
 // ============================================================================
 // Registry Functions

--- a/src/adapters/sql/adapter.ts
+++ b/src/adapters/sql/adapter.ts
@@ -1,0 +1,307 @@
+/**
+ * SQL DDL Adapter
+ *
+ * Extracts schemas from SQL DDL files (CREATE TABLE, CREATE TYPE, etc.)
+ * and converts them to normalized schema format.
+ *
+ * @module adapters/sql/adapter
+ */
+
+import { readFileSync } from 'fs';
+import { glob } from 'glob';
+import { resolve, basename } from 'path';
+import type {
+  SchemaAdapter,
+  SchemaRef,
+  NormalizedSchema,
+  NormalizedType,
+  PropertyDef,
+} from '../../core/types.js';
+import { DDLParser, parseDDL } from './ddl-parser.js';
+import { SQL_TYPE_MAP } from './types.js';
+import type { SQLTable, SQLColumn, SQLEnum, SQLDialect } from './types.js';
+
+/**
+ * Adapter for SQL DDL schema extraction
+ */
+export class SQLAdapter implements SchemaAdapter {
+  readonly kind = 'sql_ddl' as const;
+
+  /**
+   * Check if this adapter supports the given schema reference
+   */
+  supports(ref: SchemaRef): boolean {
+    return ref.source === 'sql_ddl';
+  }
+
+  /**
+   * Extract schema from a SQL file or table reference
+   *
+   * @param ref Schema reference with id format: "file:/path/to/file.sql" or "table:tablename"
+   */
+  async extract(ref: SchemaRef): Promise<NormalizedSchema> {
+    const { id, options } = ref;
+    const dialect = (options?.dialect as SQLDialect) || 'postgresql';
+
+    // Parse the reference ID
+    if (id.startsWith('file:')) {
+      const filePath = id.slice(5);
+      return this.extractFromFile(filePath, dialect, options?.table as string);
+    } else if (id.startsWith('table:')) {
+      const tableName = id.slice(6);
+      const filePath = options?.file as string;
+      if (!filePath) {
+        throw new Error('SQL table reference requires "file" option');
+      }
+      return this.extractFromFile(filePath, dialect, tableName);
+    }
+
+    throw new Error(`Invalid SQL schema reference: ${id}`);
+  }
+
+  /**
+   * List all available schemas in a directory
+   */
+  async list(basePath: string): Promise<SchemaRef[]> {
+    const refs: SchemaRef[] = [];
+
+    // Find all .sql files
+    const sqlFiles = await glob('**/*.sql', {
+      cwd: basePath,
+      absolute: true,
+      ignore: ['**/node_modules/**'],
+    });
+
+    for (const file of sqlFiles) {
+      try {
+        const content = readFileSync(file, 'utf-8');
+        const result = parseDDL(content);
+
+        // Add a ref for each table
+        for (const table of result.tables) {
+          refs.push({
+            source: 'sql_ddl',
+            id: `table:${table.name}`,
+            options: { file, table: table.name },
+          });
+        }
+      } catch {
+        // Skip files that can't be parsed
+      }
+    }
+
+    return refs;
+  }
+
+  /**
+   * Extract schema from a SQL file
+   */
+  private extractFromFile(
+    filePath: string,
+    dialect: SQLDialect,
+    tableName?: string
+  ): NormalizedSchema {
+    const absolutePath = resolve(filePath);
+    const content = readFileSync(absolutePath, 'utf-8');
+    const result = parseDDL(content, dialect);
+
+    if (tableName) {
+      // Find specific table
+      const table = result.tables.find(
+        t => t.name.toLowerCase() === tableName.toLowerCase()
+      );
+      if (!table) {
+        throw new Error(`Table "${tableName}" not found in ${filePath}`);
+      }
+      return this.tableToSchema(table, result.enums, filePath);
+    }
+
+    // Return all tables as a combined schema
+    if (result.tables.length === 0) {
+      throw new Error(`No tables found in ${filePath}`);
+    }
+
+    if (result.tables.length === 1) {
+      return this.tableToSchema(result.tables[0], result.enums, filePath);
+    }
+
+    // Multiple tables - create a schema with each table as a property
+    const properties: Record<string, PropertyDef> = {};
+    for (const table of result.tables) {
+      properties[table.name] = {
+        type: {
+          kind: 'object',
+          schema: this.tableToSchema(table, result.enums, filePath),
+        },
+        optional: false,
+        nullable: false,
+        readonly: false,
+        deprecated: false,
+      };
+    }
+
+    return {
+      name: basename(filePath, '.sql'),
+      properties,
+      required: result.tables.map(t => t.name),
+      source: { source: 'sql_ddl', id: `file:${filePath}` },
+      location: { file: absolutePath, line: 1 },
+    };
+  }
+
+  /**
+   * Convert a SQL table to normalized schema
+   */
+  private tableToSchema(
+    table: SQLTable,
+    enums: SQLEnum[],
+    filePath: string
+  ): NormalizedSchema {
+    const properties: Record<string, PropertyDef> = {};
+    const required: string[] = [];
+
+    for (const column of table.columns) {
+      const type = this.columnToType(column, enums);
+      const optional = column.nullable && !column.isPrimaryKey;
+
+      properties[column.name] = {
+        type,
+        optional,
+        nullable: column.nullable,
+        readonly: false,
+        deprecated: false,
+        description: this.buildColumnDescription(column),
+        constraints: this.extractConstraints(column),
+      };
+
+      if (!optional) {
+        required.push(column.name);
+      }
+    }
+
+    return {
+      name: table.name,
+      properties,
+      required,
+      source: {
+        source: 'sql_ddl',
+        id: `table:${table.name}`,
+        options: { file: filePath },
+      },
+      location: { file: resolve(filePath), line: 1 },
+    };
+  }
+
+  /**
+   * Convert a SQL column to normalized type
+   */
+  private columnToType(column: SQLColumn, enums: SQLEnum[]): NormalizedType {
+    let { dataType } = column;
+    let isArray = false;
+
+    // Check for array type
+    if (dataType.endsWith('[]')) {
+      isArray = true;
+      dataType = dataType.slice(0, -2);
+    }
+
+    // Check for enum type
+    if (dataType.startsWith('enum:')) {
+      const enumName = dataType.slice(5);
+      const enumDef = enums.find(e => e.name === enumName);
+      if (enumDef) {
+        const enumType: NormalizedType = {
+          kind: 'union',
+          variants: enumDef.values.map(v => ({ kind: 'literal' as const, value: v })),
+        };
+        return isArray ? { kind: 'array', element: enumType } : enumType;
+      }
+    }
+
+    // Remove size specification for lookup (e.g., varchar(255) -> varchar)
+    const baseType = dataType.replace(/\s*\([^)]+\)/, '').toLowerCase();
+
+    // Look up type mapping
+    const mapped = SQL_TYPE_MAP[baseType];
+    let normalizedType: NormalizedType;
+
+    if (mapped) {
+      if (mapped.kind === 'primitive' && mapped.value) {
+        normalizedType = { kind: 'primitive', value: mapped.value as 'string' | 'number' | 'boolean' | 'null' };
+      } else if (mapped.kind === 'any') {
+        normalizedType = { kind: 'any' };
+      } else {
+        normalizedType = { kind: 'unknown' };
+      }
+    } else {
+      // Unknown type - might be a custom enum or type
+      normalizedType = { kind: 'ref', name: dataType };
+    }
+
+    // Wrap in array if needed
+    if (isArray) {
+      return { kind: 'array', element: normalizedType };
+    }
+
+    // Handle nullable
+    if (column.nullable) {
+      return {
+        kind: 'union',
+        variants: [normalizedType, { kind: 'primitive', value: 'null' }],
+      };
+    }
+
+    return normalizedType;
+  }
+
+  /**
+   * Build a description for a column
+   */
+  private buildColumnDescription(column: SQLColumn): string | undefined {
+    const parts: string[] = [];
+
+    if (column.isPrimaryKey) {
+      parts.push('Primary key');
+    }
+    if (column.isUnique) {
+      parts.push('Unique');
+    }
+    if (column.references) {
+      parts.push(`References ${column.references.table}(${column.references.column})`);
+    }
+    if (column.defaultValue) {
+      parts.push(`Default: ${column.defaultValue}`);
+    }
+
+    return parts.length > 0 ? parts.join('. ') : undefined;
+  }
+
+  /**
+   * Extract constraints from column definition
+   */
+  private extractConstraints(column: SQLColumn): Record<string, unknown> | undefined {
+    const constraints: Record<string, unknown> = {};
+
+    // Check for varchar/char length constraint
+    const lengthMatch = column.dataType.match(/\((\d+)\)/);
+    if (lengthMatch) {
+      constraints.maxLength = parseInt(lengthMatch[1], 10);
+    }
+
+    // Check for numeric precision
+    const precisionMatch = column.dataType.match(/\((\d+),\s*(\d+)\)/);
+    if (precisionMatch) {
+      constraints.precision = parseInt(precisionMatch[1], 10);
+      constraints.scale = parseInt(precisionMatch[2], 10);
+    }
+
+    // Check constraints
+    for (const constraint of column.constraints) {
+      if (constraint.type === 'CHECK' && constraint.expression) {
+        constraints.check = constraint.expression;
+      }
+    }
+
+    return Object.keys(constraints).length > 0 ? constraints : undefined;
+  }
+}

--- a/src/adapters/sql/ddl-parser.ts
+++ b/src/adapters/sql/ddl-parser.ts
@@ -1,0 +1,360 @@
+/**
+ * SQL DDL Parser
+ *
+ * Parses SQL DDL statements (CREATE TABLE, CREATE TYPE, ALTER TABLE)
+ * and extracts schema information.
+ *
+ * Supports PostgreSQL, MySQL, and SQLite dialects.
+ *
+ * @module adapters/sql/ddl-parser
+ */
+
+import type {
+  SQLDialect,
+  SQLTable,
+  SQLColumn,
+  SQLEnum,
+  SQLParseResult,
+  SQLForeignKey,
+  SQLConstraint,
+} from './types.js';
+
+/**
+ * DDL Parser for SQL schema extraction
+ */
+export class DDLParser {
+  private dialect: SQLDialect;
+
+  constructor(dialect: SQLDialect = 'postgresql') {
+    this.dialect = dialect;
+  }
+
+  /**
+   * Parse SQL DDL content and extract schema information
+   */
+  parse(content: string): SQLParseResult {
+    const tables: SQLTable[] = [];
+    const enums: SQLEnum[] = [];
+
+    // Normalize content: remove comments, normalize whitespace
+    const normalized = this.normalizeSQL(content);
+
+    // Extract CREATE TYPE (enums) - PostgreSQL
+    const enumMatches = normalized.matchAll(
+      /CREATE\s+TYPE\s+(?:(?:"([^"]+)"|(\w+))\.)?(?:"([^"]+)"|(\w+))\s+AS\s+ENUM\s*\(\s*([^)]+)\s*\)/gi
+    );
+    for (const match of enumMatches) {
+      const schema = match[1] || match[2];
+      const name = match[3] || match[4];
+      const valuesStr = match[5];
+      const values = this.parseEnumValues(valuesStr);
+      enums.push({ name, schema, values });
+    }
+
+    // Extract CREATE TABLE statements
+    const tableMatches = normalized.matchAll(
+      /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:(?:"([^"]+)"|(\w+))\.)?(?:"([^"]+)"|(\w+))\s*\(\s*([\s\S]*?)\s*\)(?:\s*;|\s*$)/gi
+    );
+    for (const match of tableMatches) {
+      const schema = match[1] || match[2];
+      const name = match[3] || match[4];
+      const columnsStr = match[5];
+      const table = this.parseTableBody(name, schema, columnsStr, enums);
+      tables.push(table);
+    }
+
+    // Handle ALTER TABLE ADD COLUMN
+    const alterMatches = normalized.matchAll(
+      /ALTER\s+TABLE\s+(?:(?:"([^"]+)"|(\w+))\.)?(?:"([^"]+)"|(\w+))\s+ADD\s+(?:COLUMN\s+)?(?:"([^"]+)"|(\w+))\s+([^;,]+)/gi
+    );
+    for (const match of alterMatches) {
+      const tableName = match[3] || match[4];
+      const columnName = match[5] || match[6];
+      const columnDef = match[7];
+
+      const table = tables.find(t => t.name === tableName);
+      if (table) {
+        const column = this.parseColumnDefinition(columnName, columnDef.trim(), enums);
+        table.columns.push(column);
+      }
+    }
+
+    return { tables, enums, dialect: this.dialect };
+  }
+
+  /**
+   * Normalize SQL content for easier parsing
+   */
+  private normalizeSQL(content: string): string {
+    return content
+      // Remove single-line comments
+      .replace(/--[^\n]*/g, '')
+      // Remove multi-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      // Normalize whitespace
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  /**
+   * Parse enum values from string
+   */
+  private parseEnumValues(valuesStr: string): string[] {
+    const values: string[] = [];
+    const matches = valuesStr.matchAll(/'([^']+)'/g);
+    for (const match of matches) {
+      values.push(match[1]);
+    }
+    return values;
+  }
+
+  /**
+   * Parse table body (columns and constraints)
+   */
+  private parseTableBody(
+    name: string,
+    schema: string | undefined,
+    body: string,
+    enums: SQLEnum[]
+  ): SQLTable {
+    const columns: SQLColumn[] = [];
+    const primaryKey: string[] = [];
+    const uniqueConstraints: string[][] = [];
+    const foreignKeys: SQLForeignKey[] = [];
+    const checkConstraints: string[] = [];
+
+    // Split by comma, but respect parentheses
+    const parts = this.splitTableBody(body);
+
+    for (const part of parts) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+
+      // Check for table-level constraints
+      if (/^PRIMARY\s+KEY/i.test(trimmed)) {
+        const pkMatch = trimmed.match(/PRIMARY\s+KEY\s*\(\s*([^)]+)\s*\)/i);
+        if (pkMatch) {
+          const cols = this.parseColumnList(pkMatch[1]);
+          primaryKey.push(...cols);
+        }
+      } else if (/^UNIQUE/i.test(trimmed)) {
+        const ukMatch = trimmed.match(/UNIQUE\s*\(\s*([^)]+)\s*\)/i);
+        if (ukMatch) {
+          const cols = this.parseColumnList(ukMatch[1]);
+          uniqueConstraints.push(cols);
+        }
+      } else if (/^FOREIGN\s+KEY/i.test(trimmed)) {
+        const fkMatch = trimmed.match(
+          /FOREIGN\s+KEY\s*\(\s*([^)]+)\s*\)\s*REFERENCES\s+(?:"([^"]+)"|(\w+))\s*\(\s*([^)]+)\s*\)/i
+        );
+        if (fkMatch) {
+          foreignKeys.push({
+            table: fkMatch[2] || fkMatch[3],
+            column: this.parseColumnList(fkMatch[4])[0],
+          });
+        }
+      } else if (/^CHECK/i.test(trimmed)) {
+        const checkMatch = trimmed.match(/CHECK\s*\(\s*(.+)\s*\)/i);
+        if (checkMatch) {
+          checkConstraints.push(checkMatch[1]);
+        }
+      } else if (/^CONSTRAINT/i.test(trimmed)) {
+        // Named constraint - parse the type
+        if (/PRIMARY\s+KEY/i.test(trimmed)) {
+          const pkMatch = trimmed.match(/PRIMARY\s+KEY\s*\(\s*([^)]+)\s*\)/i);
+          if (pkMatch) {
+            primaryKey.push(...this.parseColumnList(pkMatch[1]));
+          }
+        } else if (/UNIQUE/i.test(trimmed)) {
+          const ukMatch = trimmed.match(/UNIQUE\s*\(\s*([^)]+)\s*\)/i);
+          if (ukMatch) {
+            uniqueConstraints.push(this.parseColumnList(ukMatch[1]));
+          }
+        } else if (/FOREIGN\s+KEY/i.test(trimmed)) {
+          const fkMatch = trimmed.match(
+            /FOREIGN\s+KEY\s*\(\s*([^)]+)\s*\)\s*REFERENCES\s+(?:"([^"]+)"|(\w+))\s*\(\s*([^)]+)\s*\)/i
+          );
+          if (fkMatch) {
+            foreignKeys.push({
+              table: fkMatch[2] || fkMatch[3],
+              column: this.parseColumnList(fkMatch[4])[0],
+            });
+          }
+        } else if (/CHECK/i.test(trimmed)) {
+          const checkMatch = trimmed.match(/CHECK\s*\(\s*(.+)\s*\)/i);
+          if (checkMatch) {
+            checkConstraints.push(checkMatch[1]);
+          }
+        }
+      } else {
+        // Column definition
+        const column = this.parseColumnFromPart(trimmed, enums);
+        if (column) {
+          columns.push(column);
+          if (column.isPrimaryKey) {
+            primaryKey.push(column.name);
+          }
+        }
+      }
+    }
+
+    return {
+      name,
+      schema,
+      columns,
+      primaryKey: primaryKey.length > 0 ? primaryKey : undefined,
+      uniqueConstraints,
+      foreignKeys,
+      checkConstraints,
+    };
+  }
+
+  /**
+   * Split table body by commas, respecting parentheses
+   */
+  private splitTableBody(body: string): string[] {
+    const parts: string[] = [];
+    let current = '';
+    let depth = 0;
+
+    for (const char of body) {
+      if (char === '(') {
+        depth++;
+        current += char;
+      } else if (char === ')') {
+        depth--;
+        current += char;
+      } else if (char === ',' && depth === 0) {
+        parts.push(current.trim());
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+
+    if (current.trim()) {
+      parts.push(current.trim());
+    }
+
+    return parts;
+  }
+
+  /**
+   * Parse column list from string
+   */
+  private parseColumnList(str: string): string[] {
+    return str
+      .split(',')
+      .map(s => s.trim().replace(/^"|"$/g, ''))
+      .filter(Boolean);
+  }
+
+  /**
+   * Parse a column from table body part
+   */
+  private parseColumnFromPart(part: string, enums: SQLEnum[]): SQLColumn | null {
+    // Match column name and type
+    const match = part.match(/^(?:"([^"]+)"|(\w+))\s+(.+)$/i);
+    if (!match) return null;
+
+    const name = match[1] || match[2];
+    const rest = match[3];
+
+    return this.parseColumnDefinition(name, rest, enums);
+  }
+
+  /**
+   * Parse column definition
+   */
+  private parseColumnDefinition(
+    name: string,
+    definition: string,
+    enums: SQLEnum[]
+  ): SQLColumn {
+    const constraints: SQLConstraint[] = [];
+    let nullable = true;
+    let isPrimaryKey = false;
+    let isUnique = false;
+    let defaultValue: string | undefined;
+    let references: SQLForeignKey | undefined;
+
+    // Extract data type (first word or type with parentheses)
+    const typeMatch = definition.match(/^(\w+(?:\s*\([^)]+\))?(?:\s*\[\])?)/i);
+    let dataType = typeMatch ? typeMatch[1].trim().toLowerCase() : 'text';
+
+    // Check for array type
+    const isArray = /\[\]$/.test(dataType);
+    if (isArray) {
+      dataType = dataType.replace(/\[\]$/, '');
+    }
+
+    // Check for enum type
+    const enumType = enums.find(
+      e => e.name.toLowerCase() === dataType.toLowerCase()
+    );
+
+    // Parse constraints from rest of definition
+    const rest = definition.slice(typeMatch?.[0].length || 0).trim();
+
+    if (/\bNOT\s+NULL\b/i.test(rest)) {
+      nullable = false;
+      constraints.push({ type: 'NOT NULL' });
+    }
+
+    if (/\bNULL\b/i.test(rest) && !/\bNOT\s+NULL\b/i.test(rest)) {
+      nullable = true;
+    }
+
+    if (/\bPRIMARY\s+KEY\b/i.test(rest)) {
+      isPrimaryKey = true;
+      nullable = false;
+      constraints.push({ type: 'PRIMARY KEY' });
+    }
+
+    if (/\bUNIQUE\b/i.test(rest)) {
+      isUnique = true;
+      constraints.push({ type: 'UNIQUE' });
+    }
+
+    const defaultMatch = rest.match(/\bDEFAULT\s+([^,\s]+(?:\([^)]*\))?)/i);
+    if (defaultMatch) {
+      defaultValue = defaultMatch[1];
+      constraints.push({ type: 'DEFAULT', expression: defaultValue });
+    }
+
+    const refMatch = rest.match(
+      /\bREFERENCES\s+(?:"([^"]+)"|(\w+))\s*\(\s*(?:"([^"]+)"|(\w+))\s*\)/i
+    );
+    if (refMatch) {
+      references = {
+        table: refMatch[1] || refMatch[2],
+        column: refMatch[3] || refMatch[4],
+      };
+      constraints.push({ type: 'FOREIGN KEY' });
+    }
+
+    const checkMatch = rest.match(/\bCHECK\s*\(\s*(.+?)\s*\)/i);
+    if (checkMatch) {
+      constraints.push({ type: 'CHECK', expression: checkMatch[1] });
+    }
+
+    return {
+      name,
+      dataType: enumType ? `enum:${enumType.name}` : (isArray ? `${dataType}[]` : dataType),
+      nullable,
+      defaultValue,
+      isPrimaryKey,
+      isUnique,
+      references,
+      constraints,
+    };
+  }
+}
+
+/**
+ * Convenience function to parse SQL DDL
+ */
+export function parseDDL(content: string, dialect: SQLDialect = 'postgresql'): SQLParseResult {
+  const parser = new DDLParser(dialect);
+  return parser.parse(content);
+}

--- a/src/adapters/sql/index.ts
+++ b/src/adapters/sql/index.ts
@@ -1,0 +1,21 @@
+/**
+ * SQL DDL Adapter
+ *
+ * Exports for SQL DDL schema extraction.
+ * Supports PostgreSQL, MySQL, and SQLite dialects.
+ *
+ * @module adapters/sql
+ */
+
+export { SQLAdapter } from './adapter.js';
+export { DDLParser, parseDDL } from './ddl-parser.js';
+export type {
+  SQLDialect,
+  SQLTable,
+  SQLColumn,
+  SQLEnum,
+  SQLParseResult,
+  SQLForeignKey,
+  SQLConstraint,
+} from './types.js';
+export { SQL_TYPE_MAP } from './types.js';

--- a/src/adapters/sql/types.ts
+++ b/src/adapters/sql/types.ts
@@ -1,0 +1,144 @@
+/**
+ * SQL DDL Types
+ *
+ * Type definitions for SQL DDL parsing.
+ * Supports PostgreSQL, MySQL, and SQLite dialects.
+ *
+ * @module adapters/sql/types
+ */
+
+/**
+ * Supported SQL dialects
+ */
+export type SQLDialect = 'postgresql' | 'mysql' | 'sqlite';
+
+/**
+ * SQL column definition
+ */
+export interface SQLColumn {
+  name: string;
+  dataType: string;
+  nullable: boolean;
+  defaultValue?: string;
+  isPrimaryKey: boolean;
+  isUnique: boolean;
+  references?: SQLForeignKey;
+  constraints: SQLConstraint[];
+}
+
+/**
+ * SQL foreign key reference
+ */
+export interface SQLForeignKey {
+  table: string;
+  column: string;
+  onDelete?: 'CASCADE' | 'SET NULL' | 'SET DEFAULT' | 'RESTRICT' | 'NO ACTION';
+  onUpdate?: 'CASCADE' | 'SET NULL' | 'SET DEFAULT' | 'RESTRICT' | 'NO ACTION';
+}
+
+/**
+ * SQL constraint
+ */
+export interface SQLConstraint {
+  type: 'CHECK' | 'UNIQUE' | 'PRIMARY KEY' | 'FOREIGN KEY' | 'NOT NULL' | 'DEFAULT';
+  name?: string;
+  expression?: string;
+}
+
+/**
+ * SQL table definition
+ */
+export interface SQLTable {
+  name: string;
+  schema?: string;
+  columns: SQLColumn[];
+  primaryKey?: string[];
+  uniqueConstraints: string[][];
+  foreignKeys: SQLForeignKey[];
+  checkConstraints: string[];
+}
+
+/**
+ * SQL enum type definition
+ */
+export interface SQLEnum {
+  name: string;
+  schema?: string;
+  values: string[];
+}
+
+/**
+ * Parsed SQL DDL result
+ */
+export interface SQLParseResult {
+  tables: SQLTable[];
+  enums: SQLEnum[];
+  dialect: SQLDialect;
+}
+
+/**
+ * Map SQL types to normalized types
+ */
+export const SQL_TYPE_MAP: Record<string, { kind: string; value?: string }> = {
+  // String types
+  'text': { kind: 'primitive', value: 'string' },
+  'varchar': { kind: 'primitive', value: 'string' },
+  'char': { kind: 'primitive', value: 'string' },
+  'character varying': { kind: 'primitive', value: 'string' },
+  'character': { kind: 'primitive', value: 'string' },
+  'uuid': { kind: 'primitive', value: 'string' },
+  'citext': { kind: 'primitive', value: 'string' },
+
+  // Numeric types
+  'integer': { kind: 'primitive', value: 'number' },
+  'int': { kind: 'primitive', value: 'number' },
+  'int4': { kind: 'primitive', value: 'number' },
+  'int8': { kind: 'primitive', value: 'number' },
+  'smallint': { kind: 'primitive', value: 'number' },
+  'bigint': { kind: 'primitive', value: 'number' },
+  'serial': { kind: 'primitive', value: 'number' },
+  'bigserial': { kind: 'primitive', value: 'number' },
+  'smallserial': { kind: 'primitive', value: 'number' },
+  'decimal': { kind: 'primitive', value: 'number' },
+  'numeric': { kind: 'primitive', value: 'number' },
+  'real': { kind: 'primitive', value: 'number' },
+  'float': { kind: 'primitive', value: 'number' },
+  'float4': { kind: 'primitive', value: 'number' },
+  'float8': { kind: 'primitive', value: 'number' },
+  'double precision': { kind: 'primitive', value: 'number' },
+  'money': { kind: 'primitive', value: 'number' },
+
+  // Boolean types
+  'boolean': { kind: 'primitive', value: 'boolean' },
+  'bool': { kind: 'primitive', value: 'boolean' },
+
+  // Date/Time types (represented as strings in JSON)
+  'date': { kind: 'primitive', value: 'string' },
+  'time': { kind: 'primitive', value: 'string' },
+  'timestamp': { kind: 'primitive', value: 'string' },
+  'timestamptz': { kind: 'primitive', value: 'string' },
+  'timestamp with time zone': { kind: 'primitive', value: 'string' },
+  'timestamp without time zone': { kind: 'primitive', value: 'string' },
+  'interval': { kind: 'primitive', value: 'string' },
+
+  // JSON types
+  'json': { kind: 'any' },
+  'jsonb': { kind: 'any' },
+
+  // Binary types
+  'bytea': { kind: 'primitive', value: 'string' },
+  'blob': { kind: 'primitive', value: 'string' },
+
+  // Array types (handled specially in parser)
+  // Network types
+  'inet': { kind: 'primitive', value: 'string' },
+  'cidr': { kind: 'primitive', value: 'string' },
+  'macaddr': { kind: 'primitive', value: 'string' },
+
+  // Geometric types
+  'point': { kind: 'any' },
+  'line': { kind: 'any' },
+  'box': { kind: 'any' },
+  'circle': { kind: 'any' },
+  'polygon': { kind: 'any' },
+};

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -27,6 +27,7 @@ export type SchemaSourceKind =
   | "json_schema"
   | "typebox"
   // Database Layer
+  | "sql_ddl"
   | "prisma"
   | "drizzle"
   | "typeorm"

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,12 +129,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: 'extract_schemas',
-        description: 'Extract API schemas from source code. Supports: MCP tools (Zod), OpenAPI/Swagger specs, GraphQL SDL, tRPC routers, REST endpoints (Express/Fastify), gRPC/Protobuf services, Python (FastAPI/Flask decorators), and Go (Gin/Chi handlers). Auto-detects format from file contents.',
+        description: 'Extract API schemas from source code. Supports: MCP tools (Zod), OpenAPI/Swagger specs, GraphQL SDL, tRPC routers, REST endpoints (Express/Fastify), gRPC/Protobuf services, Python (FastAPI/Flask decorators), Go (Gin/Chi handlers), and SQL DDL (CREATE TABLE, CREATE TYPE). Auto-detects format from file contents.',
         inputSchema: {
           type: 'object',
           properties: {
             rootDir: { type: 'string', description: 'Root directory of server/API source code' },
-            include: { type: 'array', items: { type: 'string' }, description: 'Glob patterns to include (e.g., **/*.ts, **/*.py, **/*.go, **/*.proto)' },
+            include: { type: 'array', items: { type: 'string' }, description: 'Glob patterns to include (e.g., **/*.ts, **/*.py, **/*.go, **/*.proto, **/*.sql)' },
             exclude: { type: 'array', items: { type: 'string' }, description: 'Glob patterns to exclude' },
           },
           required: ['rootDir'],
@@ -142,7 +142,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'extract_file',
-        description: 'Extract API schemas from a single file. Supports TypeScript, Python, Go, Protobuf, GraphQL SDL, and OpenAPI JSON/YAML.',
+        description: 'Extract API schemas from a single file. Supports TypeScript, Python, Go, Protobuf, GraphQL SDL, OpenAPI JSON/YAML, and SQL DDL.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/test/sql-ddl.test.ts
+++ b/test/sql-ddl.test.ts
@@ -1,0 +1,592 @@
+/**
+ * SQL DDL Parser Tests
+ *
+ * Tests for SQL DDL parsing and schema extraction.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DDLParser, parseDDL, SQLAdapter } from '../src/adapters/sql/index.js';
+import { bootstrapAdapters, hasAdapter, getAdapter } from '../src/adapters/index.js';
+import type { SQLTable, SQLEnum } from '../src/adapters/sql/types.js';
+
+describe('SQL DDL Parser', () => {
+  describe('DDLParser', () => {
+    describe('CREATE TABLE parsing', () => {
+      it('should parse a simple CREATE TABLE statement', () => {
+        const sql = `
+          CREATE TABLE users (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(255) NOT NULL,
+            email TEXT UNIQUE
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.tables).toHaveLength(1);
+        expect(result.tables[0].name).toBe('users');
+        expect(result.tables[0].columns).toHaveLength(3);
+      });
+
+      it('should parse column types correctly', () => {
+        const sql = `
+          CREATE TABLE test (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR(100),
+            amount DECIMAL(10,2),
+            active BOOLEAN DEFAULT true,
+            created_at TIMESTAMPTZ DEFAULT now()
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.columns.find(c => c.name === 'id')?.dataType).toBe('integer');
+        expect(table.columns.find(c => c.name === 'name')?.dataType).toBe('varchar(100)');
+        expect(table.columns.find(c => c.name === 'amount')?.dataType).toBe('decimal(10,2)');
+        expect(table.columns.find(c => c.name === 'active')?.dataType).toBe('boolean');
+        expect(table.columns.find(c => c.name === 'created_at')?.dataType).toBe('timestamptz');
+      });
+
+      it('should parse NOT NULL constraints', () => {
+        const sql = `
+          CREATE TABLE test (
+            required_field TEXT NOT NULL,
+            optional_field TEXT
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.columns.find(c => c.name === 'required_field')?.nullable).toBe(false);
+        expect(table.columns.find(c => c.name === 'optional_field')?.nullable).toBe(true);
+      });
+
+      it('should parse PRIMARY KEY constraint', () => {
+        const sql = `
+          CREATE TABLE test (
+            id UUID PRIMARY KEY,
+            name TEXT
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.columns.find(c => c.name === 'id')?.isPrimaryKey).toBe(true);
+        expect(table.primaryKey).toContain('id');
+      });
+
+      it('should parse UNIQUE constraint', () => {
+        const sql = `
+          CREATE TABLE test (
+            email TEXT UNIQUE NOT NULL,
+            phone TEXT
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.columns.find(c => c.name === 'email')?.isUnique).toBe(true);
+        expect(table.columns.find(c => c.name === 'phone')?.isUnique).toBe(false);
+      });
+
+      it('should parse DEFAULT values', () => {
+        const sql = `
+          CREATE TABLE test (
+            status TEXT DEFAULT 'pending',
+            count INTEGER DEFAULT 0,
+            active BOOLEAN DEFAULT true,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.columns.find(c => c.name === 'status')?.defaultValue).toBe("'pending'");
+        expect(table.columns.find(c => c.name === 'count')?.defaultValue).toBe('0');
+        expect(table.columns.find(c => c.name === 'active')?.defaultValue).toBe('true');
+      });
+
+      it('should parse REFERENCES (foreign key)', () => {
+        const sql = `
+          CREATE TABLE orders (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER REFERENCES users(id),
+            product_id INTEGER REFERENCES products(id)
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        const userIdCol = table.columns.find(c => c.name === 'user_id');
+        expect(userIdCol?.references?.table).toBe('users');
+        expect(userIdCol?.references?.column).toBe('id');
+
+        const productIdCol = table.columns.find(c => c.name === 'product_id');
+        expect(productIdCol?.references?.table).toBe('products');
+        expect(productIdCol?.references?.column).toBe('id');
+      });
+
+      it('should parse table with schema prefix', () => {
+        const sql = `
+          CREATE TABLE public.users (
+            id SERIAL PRIMARY KEY
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.tables[0].name).toBe('users');
+        expect(result.tables[0].schema).toBe('public');
+      });
+
+      it('should parse quoted identifiers', () => {
+        const sql = `
+          CREATE TABLE "User Profile" (
+            "user id" SERIAL PRIMARY KEY,
+            "full name" TEXT NOT NULL
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.tables[0].name).toBe('User Profile');
+        expect(result.tables[0].columns[0].name).toBe('user id');
+        expect(result.tables[0].columns[1].name).toBe('full name');
+      });
+
+      it('should parse IF NOT EXISTS', () => {
+        const sql = `
+          CREATE TABLE IF NOT EXISTS users (
+            id SERIAL PRIMARY KEY
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.tables).toHaveLength(1);
+        expect(result.tables[0].name).toBe('users');
+      });
+
+      it('should parse array types', () => {
+        const sql = `
+          CREATE TABLE test (
+            tags TEXT[],
+            scores INTEGER[]
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.columns.find(c => c.name === 'tags')?.dataType).toBe('text[]');
+        expect(table.columns.find(c => c.name === 'scores')?.dataType).toBe('integer[]');
+      });
+
+      it('should parse table-level PRIMARY KEY constraint', () => {
+        const sql = `
+          CREATE TABLE test (
+            user_id INTEGER,
+            role_id INTEGER,
+            PRIMARY KEY (user_id, role_id)
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.primaryKey).toContain('user_id');
+        expect(table.primaryKey).toContain('role_id');
+      });
+
+      it('should parse table-level UNIQUE constraint', () => {
+        const sql = `
+          CREATE TABLE test (
+            email TEXT,
+            phone TEXT,
+            UNIQUE (email, phone)
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.uniqueConstraints).toHaveLength(1);
+        expect(table.uniqueConstraints[0]).toContain('email');
+        expect(table.uniqueConstraints[0]).toContain('phone');
+      });
+
+      it('should parse table-level FOREIGN KEY constraint', () => {
+        const sql = `
+          CREATE TABLE orders (
+            id SERIAL,
+            user_id INTEGER,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.foreignKeys).toHaveLength(1);
+        expect(table.foreignKeys[0].table).toBe('users');
+        expect(table.foreignKeys[0].column).toBe('id');
+      });
+
+      it('should parse named constraints', () => {
+        const sql = `
+          CREATE TABLE test (
+            id SERIAL,
+            email TEXT,
+            CONSTRAINT pk_test PRIMARY KEY (id),
+            CONSTRAINT uk_email UNIQUE (email)
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.primaryKey).toContain('id');
+        expect(table.uniqueConstraints[0]).toContain('email');
+      });
+
+      it('should parse CHECK constraints', () => {
+        const sql = `
+          CREATE TABLE test (
+            age INTEGER CHECK (age >= 0),
+            status TEXT,
+            CONSTRAINT valid_status CHECK (status IN ('active', 'inactive'))
+          );
+        `;
+
+        const result = parseDDL(sql);
+        const table = result.tables[0];
+
+        expect(table.columns.find(c => c.name === 'age')?.constraints).toContainEqual(
+          expect.objectContaining({ type: 'CHECK' })
+        );
+        expect(table.checkConstraints).toHaveLength(1);
+      });
+    });
+
+    describe('CREATE TYPE (ENUM) parsing', () => {
+      it('should parse a simple ENUM type', () => {
+        const sql = `
+          CREATE TYPE status AS ENUM ('pending', 'active', 'completed');
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.enums).toHaveLength(1);
+        expect(result.enums[0].name).toBe('status');
+        expect(result.enums[0].values).toEqual(['pending', 'active', 'completed']);
+      });
+
+      it('should parse ENUM with schema prefix', () => {
+        const sql = `
+          CREATE TYPE public.user_role AS ENUM ('admin', 'user', 'guest');
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.enums[0].name).toBe('user_role');
+        expect(result.enums[0].schema).toBe('public');
+        expect(result.enums[0].values).toEqual(['admin', 'user', 'guest']);
+      });
+
+      it('should parse quoted ENUM type name', () => {
+        const sql = `
+          CREATE TYPE "User Status" AS ENUM ('pending', 'active');
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.enums[0].name).toBe('User Status');
+      });
+
+      it('should use ENUM in table column', () => {
+        const sql = `
+          CREATE TYPE status AS ENUM ('pending', 'active', 'completed');
+          CREATE TABLE tasks (
+            id SERIAL PRIMARY KEY,
+            status status DEFAULT 'pending'
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.enums).toHaveLength(1);
+        expect(result.tables).toHaveLength(1);
+        expect(result.tables[0].columns.find(c => c.name === 'status')?.dataType).toBe('enum:status');
+      });
+    });
+
+    describe('ALTER TABLE parsing', () => {
+      it('should parse ALTER TABLE ADD COLUMN', () => {
+        const sql = `
+          CREATE TABLE users (
+            id SERIAL PRIMARY KEY
+          );
+          ALTER TABLE users ADD COLUMN email TEXT NOT NULL;
+          ALTER TABLE users ADD name VARCHAR(255);
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.tables[0].columns).toHaveLength(3);
+        expect(result.tables[0].columns.map(c => c.name)).toContain('email');
+        expect(result.tables[0].columns.map(c => c.name)).toContain('name');
+      });
+    });
+
+    describe('Comment handling', () => {
+      it('should ignore single-line comments', () => {
+        const sql = `
+          -- This is a comment
+          CREATE TABLE users (
+            id SERIAL PRIMARY KEY -- inline comment
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.tables).toHaveLength(1);
+        expect(result.tables[0].columns).toHaveLength(1);
+      });
+
+      it('should ignore multi-line comments', () => {
+        const sql = `
+          /*
+           * Multi-line comment
+           */
+          CREATE TABLE users (
+            id SERIAL PRIMARY KEY
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.tables).toHaveLength(1);
+      });
+    });
+
+    describe('Multiple statements', () => {
+      it('should parse multiple CREATE TABLE statements', () => {
+        const sql = `
+          CREATE TABLE users (
+            id SERIAL PRIMARY KEY,
+            name TEXT
+          );
+
+          CREATE TABLE posts (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER REFERENCES users(id),
+            title TEXT
+          );
+
+          CREATE TABLE comments (
+            id SERIAL PRIMARY KEY,
+            post_id INTEGER REFERENCES posts(id),
+            body TEXT
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        expect(result.tables).toHaveLength(3);
+        expect(result.tables.map(t => t.name)).toEqual(['users', 'posts', 'comments']);
+      });
+    });
+
+    describe('Supabase migration format', () => {
+      it('should parse typical Supabase migration', () => {
+        const sql = `
+          -- Create enum for connection intent
+          CREATE TYPE connection_intent_type AS ENUM (
+            'not_looking',
+            'seeking_sponsor',
+            'open_to_sponsoring',
+            'open_to_both'
+          );
+
+          -- Add columns to profiles
+          ALTER TABLE profiles ADD COLUMN connection_intent connection_intent_type DEFAULT 'not_looking';
+          ALTER TABLE profiles ADD COLUMN external_handles JSONB DEFAULT '{}';
+
+          -- Create relationships table
+          CREATE TABLE IF NOT EXISTS relationships (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            sponsor_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+            sponsee_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+            sponsor_reveal_consent BOOLEAN DEFAULT false,
+            sponsee_reveal_consent BOOLEAN DEFAULT false,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ DEFAULT now(),
+            CONSTRAINT unique_relationship UNIQUE (sponsor_id, sponsee_id)
+          );
+        `;
+
+        const result = parseDDL(sql);
+
+        // Check enum
+        expect(result.enums).toHaveLength(1);
+        expect(result.enums[0].name).toBe('connection_intent_type');
+        expect(result.enums[0].values).toContain('seeking_sponsor');
+
+        // Check table
+        expect(result.tables).toHaveLength(1);
+        expect(result.tables[0].name).toBe('relationships');
+        expect(result.tables[0].columns.find(c => c.name === 'sponsor_reveal_consent')?.defaultValue).toBe('false');
+      });
+    });
+  });
+
+  describe('SQLAdapter', () => {
+    beforeAll(() => {
+      bootstrapAdapters();
+    });
+
+    it('should be registered in adapter registry', () => {
+      expect(hasAdapter('sql_ddl')).toBe(true);
+    });
+
+    it('should support sql_ddl refs', () => {
+      const adapter = getAdapter('sql_ddl');
+      expect(adapter.supports({ source: 'sql_ddl', id: 'file:test.sql' })).toBe(true);
+      expect(adapter.supports({ source: 'openapi', id: 'file:test.yaml' })).toBe(false);
+    });
+
+    describe('Schema conversion', () => {
+      it('should convert SQL table to NormalizedSchema', async () => {
+        const adapter = new SQLAdapter();
+
+        // Create a temp SQL file for testing
+        const sql = `
+          CREATE TABLE users (
+            id UUID PRIMARY KEY,
+            name VARCHAR(255) NOT NULL,
+            email TEXT UNIQUE,
+            age INTEGER,
+            active BOOLEAN DEFAULT true,
+            metadata JSONB,
+            created_at TIMESTAMPTZ DEFAULT now()
+          );
+        `;
+
+        // Write to temp file
+        const fs = await import('fs');
+        const path = await import('path');
+        const os = await import('os');
+
+        const tmpDir = os.tmpdir();
+        const tmpFile = path.join(tmpDir, 'test-users.sql');
+        fs.writeFileSync(tmpFile, sql);
+
+        try {
+          const schema = await adapter.extract({
+            source: 'sql_ddl',
+            id: `file:${tmpFile}`,
+          });
+
+          expect(schema.name).toBe('users');
+          expect(schema.properties).toHaveProperty('id');
+          expect(schema.properties).toHaveProperty('name');
+          expect(schema.properties).toHaveProperty('email');
+          expect(schema.properties).toHaveProperty('age');
+          expect(schema.properties).toHaveProperty('active');
+          expect(schema.properties).toHaveProperty('metadata');
+          expect(schema.properties).toHaveProperty('created_at');
+
+          // Check required fields
+          expect(schema.required).toContain('id');
+          expect(schema.required).toContain('name');
+
+          // Check types
+          expect(schema.properties.id.type).toMatchObject({ kind: 'primitive', value: 'string' });
+          expect(schema.properties.name.type).toMatchObject({ kind: 'primitive', value: 'string' });
+          expect(schema.properties.active.type.kind).toBe('union'); // boolean | null for nullable
+          expect(schema.properties.metadata.type.kind).toBe('union'); // any | null for nullable JSONB
+        } finally {
+          fs.unlinkSync(tmpFile);
+        }
+      });
+
+      it('should convert ENUM types to union literals', async () => {
+        const adapter = new SQLAdapter();
+
+        const sql = `
+          CREATE TYPE status AS ENUM ('pending', 'active', 'completed');
+          CREATE TABLE tasks (
+            id UUID PRIMARY KEY,
+            status status NOT NULL
+          );
+        `;
+
+        const fs = await import('fs');
+        const path = await import('path');
+        const os = await import('os');
+
+        const tmpDir = os.tmpdir();
+        const tmpFile = path.join(tmpDir, 'test-enum.sql');
+        fs.writeFileSync(tmpFile, sql);
+
+        try {
+          const schema = await adapter.extract({
+            source: 'sql_ddl',
+            id: `file:${tmpFile}`,
+            options: { table: 'tasks' },
+          });
+
+          expect(schema.properties.status.type.kind).toBe('union');
+          const variants = (schema.properties.status.type as { kind: 'union'; variants: unknown[] }).variants;
+          expect(variants).toHaveLength(3);
+          expect(variants).toContainEqual({ kind: 'literal', value: 'pending' });
+          expect(variants).toContainEqual({ kind: 'literal', value: 'active' });
+          expect(variants).toContainEqual({ kind: 'literal', value: 'completed' });
+        } finally {
+          fs.unlinkSync(tmpFile);
+        }
+      });
+
+      it('should include column descriptions', async () => {
+        const adapter = new SQLAdapter();
+
+        const sql = `
+          CREATE TABLE test (
+            id UUID PRIMARY KEY,
+            user_id UUID REFERENCES users(id),
+            status TEXT UNIQUE DEFAULT 'pending'
+          );
+        `;
+
+        const fs = await import('fs');
+        const path = await import('path');
+        const os = await import('os');
+
+        const tmpDir = os.tmpdir();
+        const tmpFile = path.join(tmpDir, 'test-desc.sql');
+        fs.writeFileSync(tmpFile, sql);
+
+        try {
+          const schema = await adapter.extract({
+            source: 'sql_ddl',
+            id: `file:${tmpFile}`,
+          });
+
+          expect(schema.properties.id.description).toContain('Primary key');
+          expect(schema.properties.user_id.description).toContain('References users(id)');
+          expect(schema.properties.status.description).toContain('Unique');
+          expect(schema.properties.status.description).toContain("Default: 'pending'");
+        } finally {
+          fs.unlinkSync(tmpFile);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements [Issue #1](https://github.com/Mnehmos/mnehmos.trace.mcp/issues/1) - SQL and Database Schema Support

Adds a new SQL DDL adapter that extracts schemas from SQL files, enabling contract validation between database schemas and TypeScript/Python types.

## Features

- **CREATE TABLE parsing**: Columns, types, constraints (NOT NULL, UNIQUE, PRIMARY KEY, FOREIGN KEY, CHECK, DEFAULT)
- **CREATE TYPE ... AS ENUM**: PostgreSQL enum types converted to union of literals
- **ALTER TABLE ADD COLUMN**: Incremental column additions
- **Table-level constraints**: Composite primary keys, named constraints
- **Multi-dialect support**: PostgreSQL, MySQL, SQLite

## Type Mapping

| SQL Type | NormalizedType |
|----------|----------------|
| VARCHAR, TEXT, UUID | `{ kind: 'primitive', value: 'string' }` |
| INTEGER, SERIAL, DECIMAL | `{ kind: 'primitive', value: 'number' }` |
| BOOLEAN | `{ kind: 'primitive', value: 'boolean' }` |
| JSONB, JSON | `{ kind: 'any' }` |
| TIMESTAMPTZ, DATE | `{ kind: 'primitive', value: 'string' }` |
| Custom ENUM | `{ kind: 'union', variants: [literals] }` |

## Files Changed

| File | Purpose |
|------|---------|
| `src/adapters/sql/types.ts` | SQL type definitions and type map |
| `src/adapters/sql/ddl-parser.ts` | DDL statement parser |
| `src/adapters/sql/adapter.ts` | SchemaAdapter implementation |
| `src/adapters/sql/index.ts` | Public exports |
| `test/sql-ddl.test.ts` | 30 comprehensive tests |
| `src/core/types.ts` | Added `sql_ddl` to SchemaSourceKind |
| `src/adapters/bootstrap.ts` | Register SQLAdapter |

## Test Plan

- [x] 30 new SQL tests passing
- [x] All 1080 tests passing (1050 existing + 30 new)
- [x] Build succeeds
- [x] Tool descriptions updated

## Example Usage

```typescript
const schema = await adapter.extract({
  source: 'sql_ddl',
  id: 'file:supabase/migrations/20260117.sql',
  options: { table: 'profiles' }
});
```

Closes #1

---

🤖 Generated with [Claude Code](https://claude.ai/code)